### PR TITLE
Bg fix 000001

### DIFF
--- a/src/pages/Categorias.tsx
+++ b/src/pages/Categorias.tsx
@@ -193,7 +193,6 @@ export const Categorias: React.FC = () => {
         margin={1}
         marginTop={0}
         padding={1}
-        paddingX={2}
         display="flex"
         flexDirection="column"
         alignItems="stretch"

--- a/src/pages/Lancamentos.tsx
+++ b/src/pages/Lancamentos.tsx
@@ -101,7 +101,6 @@ export const Lancamentos = () => {
                 margin={1}
                 height="100%"
                 padding={1}
-                paddingX={2}
                 display="flex"
                 flexDirection="row"
                 alignItems="start"

--- a/src/shared/services/axios-config/interceptors/ErrorInterceptor.ts
+++ b/src/shared/services/axios-config/interceptors/ErrorInterceptor.ts
@@ -1,32 +1,21 @@
 import {AxiosError}  from 'axios';
 
 export const errorInterceptor = (error: AxiosError) => {    
-
     var data:any;
     
-    if (data === undefined)
-    {
-        localStorage.clear();
-    }
-
-    if (error.message === 'Network Error'){
-        return Promise.reject(new Error('Erro de conecção'));
-    }
-
     if (error.response?.status === 400){        
         data = error.response.data; 
         alert(data.message);
-    }
-
-    if (error.response?.status ===  401){
+    } else  if (error.response?.status ===  401){
+        localStorage.clear();
         data = error.response.data; 
         alert(data.message);
-    }
-
-    if (error.response?.status ===  415){
+    } else if (error.response?.status ===  415){
         data = error.response.data; 
         alert(data.message);
-    }  
-
+    } else if (error.message === 'Network Error'){
+         alert('Erro de conexão!');
+         localStorage.clear();
+    }
     return Promise.reject(error);
 };


### PR DESCRIPTION
Correção no tratamento de erro Ao receber status BadRequest
Ao receber status  code 401 que corresponde a unauthorized dados armazenados localmente no cliente são apagados assim como quando ocorrer falha de conexão com a API