### PR TITLE
Bugfix/fixing try catch in imagem perfil usuario service get imagem perfil usuario by id usuario

### DIFF
--- a/src/shared/services/api/ImagemPerfilUsuarioService.ts
+++ b/src/shared/services/api/ImagemPerfilUsuarioService.ts
@@ -30,7 +30,7 @@ const getImagemPerfilUsuarioByIdUsuario = async (): Promise<ImagemPerfilUsuarioV
     }
   }
   catch (error) {
-    console.log(error);
+    return null;
   }
 };
 


### PR DESCRIPTION
A API Rest retorna um BadRequest ao ocorrer erro que anteriormente retornava um OkResult, forçando assim colocar um retorno null do catch Exception no método getImagemPerfilUsuarioByIdUsuario.

const getImagemPerfilUsuarioByIdUsuario = async (): Promise<ImagemPerfilUsuarioVM | any> => {
  try {
    const accessToken = localStorage.getItem('@dpApiAccess')?.replaceAll('"', '');
    const idUsuario = Number(localStorage.getItem('idUsuario'));

    const url = `/ImagemPerfilUsuario/GetByIdUsuario/${idUsuario}`;

    const headers = {
      Authorization: `Bearer ${accessToken}`,
      'Content-Type': 'multipart/form-data',
    };

    const { data } = await Api.get(url, { headers });

    if (data.message === true) {
      return data.imagemPerfilUsuario;
    } else {
      return null;
    }
  }
  catch {
    return null;
  }
};